### PR TITLE
Makes anomaly detector restart in compose up

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,5 +1,14 @@
 version: '3.9'
 services:
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: 'rabbitmq'
+    hostname: 'rmq'
+    ports:
+      - 5672:5672
+      - 15672:15672
+
   data_generator:
     build:
       context: ../
@@ -17,6 +26,7 @@ services:
       - "8000:8000"
     depends_on:
       - postgresdb
+      - rabbitmq
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -h db -p 5432 -U postgres -d postgres"]
       interval: 10s
@@ -82,17 +92,14 @@ services:
     build:
       context: ../
       dockerfile: ./docker/anomaly_detector/Dockerfile
+    depends_on:
+      - rabbitmq
     links:
       - rabbitmq
       - controller
+    restart: always
 
-  rabbitmq:
-    image: rabbitmq:3-management
-    container_name: 'rabbitmq'
-    hostname: 'rmq'
-    ports:
-      - 5672:5672
-      - 15672:15672
+
 
   keycloak:
         environment:
@@ -103,5 +110,3 @@ services:
         command: start-dev
         ports:
           - "8080:8080"
-
-


### PR DESCRIPTION
# Description

- Moves rabbitmq to the top of compose
- Adds restart: always to anomalydetector in compose

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
