### PR TITLE
No reload

### DIFF
--- a/Dashboard_with_pages/pages/anomalies.py
+++ b/Dashboard_with_pages/pages/anomalies.py
@@ -138,7 +138,6 @@ def serve_layout():
                                                 id="OK",
                                                 className="ms-auto",
                                                 n_clicks=0,
-                                                href="/anomalies/",
                                             )
                                         ),
                                         dbc.Button(

--- a/Dashboard_with_pages/pages/anomalies.py
+++ b/Dashboard_with_pages/pages/anomalies.py
@@ -444,7 +444,6 @@ def handled_value(value):
     ],
 )
 def adjust_table(value, n, sevValue, hanValue):
-    time.sleep(0.1)
     data = getCopyDF(value)
 
     container = dashboard.dataContainer


### PR DESCRIPTION
# Description

Anomalies page now doesn't reset filters the first time an anomaly is marked as false_positve (or unmarked).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my solution up against the DOD
