### PR TITLE
Moves time interval dropdown in front of the other filtering dropdowns

### DIFF
--- a/Dashboard_with_pages/pages/anomalies.py
+++ b/Dashboard_with_pages/pages/anomalies.py
@@ -89,30 +89,14 @@ def serve_layout():
                         ),
                     ),
                 ),
-                # Dropdown menu
-                html.Div(
-                    children=[
-                        dcc.Dropdown(
-                            [
-                                "All time",
-                                "Today",
-                                "Yesterday",
-                                "Last two days",
-                                "Last 7 days",
-                                "This month",
-                            ],
-                            "Today",
-                            id="interval_picker_dropdown",
-                            style={"width": "10vw"},
-                        ),
-                    ]
-                ),
                 # This is the popup menu that is shown when the user presses the ... button.
                 html.Div(
                     [
                         dbc.Modal(
                             [
-                                dbc.ModalHeader(dbc.ModalTitle("Options"), close_button=False),
+                                dbc.ModalHeader(
+                                    dbc.ModalTitle("Options"), close_button=False
+                                ),
                                 dbc.ModalBody(
                                     html.Div(
                                         children=[
@@ -169,6 +153,19 @@ def serve_layout():
                                         "margin-top": "-5px",
                                     },
                                 ),
+                                dcc.Dropdown(
+                                    [
+                                        "All time",
+                                        "Today",
+                                        "Yesterday",
+                                        "Last two days",
+                                        "Last 7 days",
+                                        "This month",
+                                    ],
+                                    "Today",
+                                    id="interval_picker_dropdown",
+                                    style={"width": "13vw", "margin-right": "11px"},
+                                ),
                                 # Dropdown for choosing which severity level to filter by
                                 dcc.Dropdown(
                                     [
@@ -179,8 +176,7 @@ def serve_layout():
                                     ],
                                     "Any Severity",
                                     id="dropdownmenu_severity",
-                                    className="cardLine",
-                                    style={"width": "13vw", "margin-right": "8px"},
+                                    style={"width": "13vw", "margin-right": "11px"},
                                 ),
                                 dcc.Dropdown(
                                     [
@@ -190,8 +186,7 @@ def serve_layout():
                                     ],
                                     "Unhandled Anomalies",
                                     id="dropdownmenu_handled",
-                                    className="cardLine",
-                                    style={"width": "13vw", "margin-right": "8px"},
+                                    style={"width": "13vw", "margin-right": "11px"},
                                 ),
                             ],
                             style={"margin": "10px 10px 10px 10px", "display": "flex"},


### PR DESCRIPTION
# Description

Time dropdown filter has been moved to be in front of and in line with the other filtering dropdowns

## Type of change

Please delete options that are not relevant.
- [x] Visual change

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
