### PR TITLE
Removes prevent_initial_call that makes anomaly table empty when first loading page

### DIFF
--- a/Dashboard_with_pages/pages/anomalies.py
+++ b/Dashboard_with_pages/pages/anomalies.py
@@ -404,7 +404,6 @@ def handled_value(value):
         Input("dropdownmenu_severity", "value"),
         Input("dropdownmenu_handled", "value"),
     ],
-    prevent_initial_call=True,
 )
 def adjust_table(value, n, sevValue, hanValue):
     data = getCopyDF(value)


### PR DESCRIPTION
# Description
Fixes issue where anomalies page would not read the filters when entering the page from another

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
